### PR TITLE
Fix bug "JS can't work well on device with android API Level larger than 19"

### DIFF
--- a/Android/WebViewJavascriptBridge/src/com/fangjian/WebViewJavascriptBridge.java
+++ b/Android/WebViewJavascriptBridge/src/com/fangjian/WebViewJavascriptBridge.java
@@ -49,8 +49,17 @@ public class WebViewJavascriptBridge implements Serializable {
     private void loadWebViewJavascriptBridgeJs(WebView webView) {
         InputStream is=mContext.getResources().openRawResource(R.raw.webviewjavascriptbridge);
         String script=convertStreamToString(is);
-        webView.loadUrl("javascript:"+script);
 
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+			webView.evaluateJavascript("javascript:" + script, new ValueCallback<String>() {
+				@Override
+				public void onReceiveValue(String value) {
+					//TODO
+				}
+			});
+		} else {
+			webView.loadUrl("javascript:" + script);
+		}
     }
 
     public static String convertStreamToString(java.io.InputStream is) {


### PR DESCRIPTION
Fix bug "JS can't work well on device with android API Level larger than 19"
